### PR TITLE
Update black pawn movegen.

### DIFF
--- a/src/movetable.rs
+++ b/src/movetable.rs
@@ -56,8 +56,9 @@ impl Default for MoveTable {
         }
 
         shift = 0x8000000000000000; // Piece in the top left corner.
-        for i in 0..8_usize {
-            for j in 0..8_usize {
+                                    // No move generation for squares which pawns cannot visit.
+        for i in 1..7_usize {
+            for j in 1..7_usize {
                 table.insert((PieceType::BlackPawn, shift), black_pawn_moves((i, j)));
                 shift >>= 1;
             }


### PR DESCRIPTION
This commit removes move generation for black pawns on the first and last ranks of the board. No pawn can move backwards, and any pawn that reaches the last rank is promoted, so this is fine. This means the Move Table will return `Option::None` if the program attempts to look up pawn moves on these squares. There should be no case in which this happens, as that would indicate a severe logic bug.