### PR TITLE
Fix castling logic again.

### DIFF
--- a/src/gamemanager/legal_moves.rs
+++ b/src/gamemanager/legal_moves.rs
@@ -40,6 +40,14 @@ impl GameManager {
             &tbl,
         );
 
+        let currently_attacked = self.attacked_by(
+            tbl,
+            match color {
+                Color::Black => Color::White,
+                Color::White => Color::Black,
+            },
+        );
+
         // ASSERT: We will never have Super moves in the pseudolegal moves vector.
         debug_assert!(pslm
             .iter()
@@ -97,23 +105,29 @@ impl GameManager {
                 },
             );
 
-            // Test that the castle is not castling through/out of check.
+            // Test that the castle is not castling through/out of/into check.
             use Square::*;
             match mv.3 {
                 KingCastle => {
-                    if (color == Color::Black
-                        && ((E8.to_u64() | F8.to_u64() | G8.to_u64()) & enemy_attacked) != 0)
-                        || (color == Color::White
-                            && ((E1.to_u64() | F1.to_u64() | G1.to_u64()) & enemy_attacked) != 0)
+                    if color == Color::Black
+                        && ((E8.to_u64() | F8.to_u64() | G8.to_u64()) & enemy_attacked != 0
+                            || (E8.to_u64() | F8.to_u64() | G8.to_u64()) & currently_attacked != 0)
+                        || color == Color::White
+                            && ((E1.to_u64() | F1.to_u64() | G1.to_u64()) & enemy_attacked != 0
+                                || (E1.to_u64() | F1.to_u64() | G1.to_u64()) & currently_attacked
+                                    != 0)
                     {
                         continue; // We don't want this move!
                     }
                 }
                 QueenCastle => {
                     if color == Color::Black
-                        && ((E8.to_u64() | D8.to_u64() | C8.to_u64()) & enemy_attacked) != 0
+                        && ((E8.to_u64() | D8.to_u64() | C8.to_u64()) & enemy_attacked != 0
+                            || (E8.to_u64() | D8.to_u64() | C8.to_u64()) & currently_attacked != 0)
                         || color == Color::White
-                            && ((E1.to_u64() | D1.to_u64() | C1.to_u64()) & enemy_attacked) != 0
+                            && ((E1.to_u64() | D1.to_u64() | C1.to_u64()) & enemy_attacked != 0
+                                || (E1.to_u64() | D1.to_u64() | C1.to_u64()) & currently_attacked
+                                    != 0)
                     {
                         continue; // Ditto.
                     }

--- a/src/gamemanager/legal_moves/perft.rs
+++ b/src/gamemanager/legal_moves/perft.rs
@@ -13,6 +13,7 @@ pub fn perft(depth: u16, maxdepth: u16, gm: GameManager, tbl: &NoArc<MoveTable>)
 }
 
 pub fn printing_perft(depth: u16, maxdepth: u16, gm: GameManager, tbl: &NoArc<MoveTable>) {
+    //use crate::types::Square::*;
     for mv in gm.legal_moves(tbl) {
         println!(
             "{}{}: {}",

--- a/src/gamemanager/mod.rs
+++ b/src/gamemanager/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     bitboard,
     movetable::{noarc::NoArc, MoveTable},
-    types::{CastlingRecord, Color},
+    types::{CastlingRecord, Color, MoveType, PieceType, Square},
 };
 use bitboard::BitBoard;
 use pseudolegal_moves::pseudolegal_moves;
@@ -159,9 +159,27 @@ impl GameManager {
         use crate::types::MoveType::*;
         use crate::types::PieceType::*;
 
+        let movefilter: &dyn for<'a, 'b> Fn(&'a &'b (PieceType, Square, Square, MoveType)) -> bool =
+            &|mv: &&(PieceType, Square, Square, MoveType)| {
+                if mv.3 == DoublePawnPush
+                    || mv.0 == Pawn
+                        && (mv.3 == QuietMove
+                            || mv.3 == BPromotion
+                            || mv.3 == RPromotion
+                            || mv.3 == NPromotion
+                            || mv.3 == QPromotion)
+                {
+                    return false; // Rule it out if it is a pawn push.
+                } else if mv.0 == King && (mv.3 == KingCastle || mv.3 == QueenCastle) {
+                    return false; // Rule it out if it is a castling move.
+                } else {
+                    return true;
+                }
+            };
+
         moves
             .iter()
-            .filter(|mv| mv.0 != Pawn || mv.3 != QuietMove) // Isn't a pawn or isn't a pawn's quiet move.
+            .filter(movefilter) // Isn't a pawn or isn't a pawn's quiet move.
             .map(|(_, _, to, _)| to.to_u64())
             .fold(0_u64, |acc, v| acc | v)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
         "r3k2r/Pppp1ppp/1b3nbN/nP6/BBP1P3/q4N2/Pp1P2PP/R2Q1RK1 w kq - 0 1",
     );
     println!("Searched {} nodes.", perft(0, 6, gm, &tbl));
-    //printing_perft(0, 4, gm, &tbl);
+    //printing_perft(0, 1, gm, &tbl);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This filters attacked squares, and considers squares currently under attack. If this doesn't fix everything, then it may be because pawns' pseudolegal moves fn. doesn't generate diagonal attacks unless a piece is *present* on that square. It's passing my perft tests at depth 6, though!